### PR TITLE
Loosen pundit restrictions…

### DIFF
--- a/pundit_helpers.gemspec
+++ b/pundit_helpers.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "pundit", "~> 0.2.1"
+  spec.add_dependency "pundit", "~> 0.2"
 
   spec.add_development_dependency "bundler", "~> 1.5"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
As far as I can tell, `pundit 0.3` (current version) will still work with `pundit_helpers`.
