### PR TITLE
use `pundit_user` rather than `current_user`

### DIFF
--- a/lib/pundit_helpers.rb
+++ b/lib/pundit_helpers.rb
@@ -45,7 +45,7 @@ module PunditHelpers
   # @return [Boolean]
   def can?(query, record)
     query  = "#{query}?"
-    policy = Pundit.policy!(current_user, record)
+    policy = Pundit.policy!(pundit_user, record)
     !! policy.public_send(query)
   end
 end

--- a/spec/pundit_helpers_spec.rb
+++ b/spec/pundit_helpers_spec.rb
@@ -6,8 +6,8 @@ class Harness
     @helper_methods = []
   end
 
-  def current_user
-    :spec_current_user
+  def pundit_user
+    :spec_pundit_user
   end
 
   def self.helper_methods
@@ -47,7 +47,7 @@ describe PunditHelpers, "#can?" do
     policy  = double(:edit? => true)
     harness = Harness.new
 
-    expect(Pundit).to receive(:policy!).with(:spec_current_user, record).and_return(policy)
+    expect(Pundit).to receive(:policy!).with(:spec_pundit_user, record).and_return(policy)
     expect(harness.can?(:edit, record)).to be_true
   end
 
@@ -56,7 +56,7 @@ describe PunditHelpers, "#can?" do
     policy  = double(:edit? => false)
     harness = Harness.new
 
-    expect(Pundit).to receive(:policy!).with(:spec_current_user, record).and_return(policy)
+    expect(Pundit).to receive(:policy!).with(:spec_pundit_user, record).and_return(policy)
     expect(harness.can?(:edit, record)).to be_false
   end
 


### PR DESCRIPTION
In pundit 0.2.2 they smartly switch from using `current_user` to `pundit_user` that by default just returns current user.

For something like devise groups in a controller, it would be preferable to be able to override `pundit_user` rather than `current_user`