### PR TITLE
Update version to 1.1.0

### DIFF
--- a/lib/pundit_helpers/version.rb
+++ b/lib/pundit_helpers/version.rb
@@ -1,3 +1,3 @@
 module PunditHelpers
-  VERSION = "1.0.0"
+  VERSION = "1.1.0"
 end


### PR DESCRIPTION
Figured a minor version bump is appropriate because the API hasn't changed at all but we are unclamping version restrictions for Pundit